### PR TITLE
Close the AudioContext on stop

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -61,7 +61,7 @@ export const getMp3MediaRecorder = (config: GlobalConfig): Promise<typeof MediaR
 
         stop(): void {
             this.processorNode.disconnect();
-            this.audioContext.suspend();
+            this.audioContext.close();
             worker.postMessage(stopRecordingMessage());
         }
 


### PR DESCRIPTION
Browsers have limits on how many AudioContexts are open. Safari only 4, Chrome 30. We need to close the AudioContexts on stop if we need to start new recordings.